### PR TITLE
Fix X-Frame-Options formatting

### DIFF
--- a/files/en-us/web/http/headers/x-frame-options/index.md
+++ b/files/en-us/web/http/headers/x-frame-options/index.md
@@ -61,7 +61,7 @@ To configure Apache to send the `X-Frame-Options` header for all pages, add this
 
 ```
 Header always set X-Frame-Options "SAMEORIGIN"
-``
+```
 
 To configure Apache to set the `X-Frame-Options` DENY, add this to your site's configuration:
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

None

> What was wrong/why is this fix needed? (quick summary only)

The Markdown on the X-Frame-Options page was broken because of a missing backtick in the Apache section. This simply adds that third backtick to properly close the code block

> Anything else that could help us review it

See broken formatting for X-Frame-Options implementation examples